### PR TITLE
Removed the Jquery dependency to make it compatible with wrappers like Coconjs canvas+ or Ejecta.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,6 @@ For the full list of features check out our [main documentation](https://gameup.
 
 The client SDK is available on [Bower.io](http://bower.io/search/?q=gameup-sdk)
 
-The SDK depends on jQuery (~2.1.3) to make Ajax calls.
-
 ### Using [Bower.io](http://bower.io/)
 
 To include the library in your project:
@@ -28,7 +26,7 @@ bower install --save gameup-sdk
 
 To use the GameUp SDK you will need an API Key. You can get one in the GameUp [Dashboard](http://dashboard.gameup.io).
 
-The SDK has an asynchronous client API; it uses jQuery Ajax to make network calls. Every client request uses a callback function to handle API responses.
+The SDK has an asynchronous client API; Every client request uses a callback function to handle API responses.
 
 ```js
 var client = new GameUp.Client("Your API Key");
@@ -77,7 +75,7 @@ The Web SDK is still in _flux_, we're looking for [feedback](mailto:hello@gameup
 
 ### Developer notes
 
-The Web SDK is written in Typescript and uses jQuery to send and receive AJAX requests. To develop on the codebase you'll need to install:
+The Web SDK is written in Typescript. To develop on the codebase you'll need to install:
 
 - [Typescript](http://typescriptlang.org)
 - [Node.js](http://nodejs.org)

--- a/dist/gameup.js
+++ b/dist/gameup.js
@@ -41,29 +41,47 @@ var GameUp;
             }
             var ajaxSettings = {
                 contentType: 'application/json',
-                crossDomain: true,
                 timeout: 3000,
                 data: payload,
                 type: method,
                 url: to,
-                xhrFields: {
-                    mozSystem: true,
-                },
                 headers: {
                     "Authorization": "Basic " + btoa(this.apikey + ":" + gamerToken)
                 },
-                success: function (data, status, jqXHR) {
+                success: function (data, status) {
                     if (typeof callback.success == 'function') {
-                        callback.success(jqXHR.status, data);
+                        callback.success(status, data);
                     }
                 },
-                error: function (jqXHR, status, errorThrown) {
+                error: function (xhr, status) {
                     if (typeof callback.error == 'function') {
-                        callback.error(jqXHR.status, jqXHR.responseJSON);
+                        callback.error(status, xhr.responseText);
                     }
                 }
             };
-            $.ajax(ajaxSettings);
+            this.ajax(ajaxSettings);
+        };
+        Client.prototype.ajax = function (settings) {
+            var http = new XMLHttpRequest();
+            http.timeout = settings.timeout;
+            http.open(settings.type, settings.url, true);
+            http.setRequestHeader("Content-type", settings.contentType);
+            for (var key in settings.headers) {
+                http.setRequestHeader(key, settings.headers[key]);
+            }
+            http.onreadystatechange = function (e) {
+                if (http.readyState === 4) {
+                    if (http.status >= 200 && http.status < 300 || http.status === 304) {
+                        if (settings.success)
+                            settings.success(JSON.parse(http.responseText), http.status);
+                    }
+                    else {
+                        if (settings.error)
+                            settings.error(http, http.status);
+                    }
+                }
+            };
+            http.send(settings.data);
         };
         Client.prototype.sendApiRequest = function (callback, to, method, gamerToken, payload) {
             this.sendRequest(callback, this.API_URL + to, method, gamerToken, payload);


### PR DESCRIPTION
Wrappers like cocoonjs using canvas+ runtime, or ejecta, don't support DOM, if the sdk depends from Jquery we can't use it in cocoonjs.